### PR TITLE
Don't fail when the user doesn't have friends

### DIFF
--- a/fbk.gemspec
+++ b/fbk.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |spec|
   spec.name                   = "fbk"
-  spec.version                = "1.3.0"
-  spec.date                   = "2016-02-25"
+  spec.version                = "1.3.1"
+  spec.date                   = "2016-04-23"
   spec.summary                = "Interacts with Facebook's Graph API."
   spec.description            = "Interacts with Facebook's Graph API."
   spec.authors                = ["Pedro Gimenez"]

--- a/lib/fbk.rb
+++ b/lib/fbk.rb
@@ -45,6 +45,8 @@ module FBK
 
     friends = get_friends_ids(json)
 
+    return [] if friends.empty?
+
     return friends if only_one_page?(friends, json)
 
     while (json = get(json[:paging][:next])) && !json[:data].empty? do


### PR DESCRIPTION
This handles the case in which a user doesn't have any friends or when
the user doesn't grant the required permission.
